### PR TITLE
catch JSON.parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,8 +132,13 @@ const request = (url) => {
       });
 
       res.on('end', () => {
-        const r = JSON.parse(response);
-
+        let r;
+        try {
+            r = JSON.parse(response);
+        } catch(e) {
+            return reject(e);
+        }
+          
         if (r.error !== undefined) {
           const error = new Error(r.error.message);
           error.code = r.error.code;


### PR DESCRIPTION
The api sometimes returns non-json data and it crashes the module.
This pr catches and returns the error.